### PR TITLE
Expose version of SDK for debugging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,3 +13,8 @@
 
 export { default } from './client/Blockv'
 export { default as Discover } from './client/Discover'
+
+// Attach SDK version information to the window
+if (typeof window != 'undefined') window.BlockvSDKInfo = {
+    version: require('../package.json').version
+}


### PR DESCRIPTION
- Task: https://trello.com/c/JHj0Bgxt

This puts a global `BlockvSDKInfo` on the `window` so you can see which version of the SDK is being used.