### PR TITLE
Added support for multiple web sockets

### DIFF
--- a/src/client/Blockv.js
+++ b/src/client/Blockv.js
@@ -16,7 +16,7 @@ import Vatoms from './manager/Vatoms'
 import Activity from './manager/Activity'
 import ActivityApi from '../internal/net/rest/api/ActivityApi'
 import Client from '../internal/net/Client'
-import WebSockets from './manager/WebSockets'
+import MultiWebSockets from './manager/MultiWebSockets'
 import EventEmitter from '../internal/EventEmitter';
 
 export default class Blockv extends EventEmitter {
@@ -37,7 +37,7 @@ export default class Blockv extends EventEmitter {
     const activityApi = new ActivityApi(this.client)
 
     this.Activity = new Activity(activityApi)
-    this.WebSockets = new WebSockets(this.store, this.client)
+    this.WebSockets = new MultiWebSockets(this.store, this.client)
     this.UserManager = new UserManager(userApi, this.store)
     this.Vatoms = new Vatoms(this)
 

--- a/src/client/manager/MultiWebSockets.js
+++ b/src/client/manager/MultiWebSockets.js
@@ -1,0 +1,90 @@
+//
+
+import EventEmitter from '../../internal/EventEmitter'
+import WebSockets from './WebSockets'
+
+// This is a wrapper around the WebSockets class, which allows for multiple sockets to be active at once.
+// It matches the API of that class exactly.
+export default class MultiWebSockets extends EventEmitter {
+
+    constructor (store, client) {
+        super()
+
+        this.store = store
+        this.client = client
+        this.sockets = []
+
+    }
+
+    /** This will be true if the connection is ready to send and receive messages */
+    get isOpen () {
+
+        // Return true if any of the websockets are open
+        return !!this.sockets.find(s => s.isOpen)
+
+    }
+
+    /**
+     * The connect function establishes a connection to the WebSocket.
+     * @public
+     * @return {Promise<WebSockets>}
+     */
+    async connect() {
+
+        // Create sockets if needed
+        if (this.sockets.length == 0) {
+
+            // Create sockets
+            if (typeof this.store.websocketAddress == 'string') {
+                
+                // Config supplied a single websocket address
+                this.sockets.push(new WebSockets(this.store, this.client, this.store.websocketAddress))
+            
+            } else if (Array.isArray(this.store.websocketAddress)) {
+
+                // Config supplied an array of addresses
+                for (let address of this.store.websocketAddress)
+                this.sockets.push(new WebSockets(this.store, this.client, address))
+
+            }
+
+            // Override the newly created socket's trigger() and emit() to instead trigger and emit on us
+            for (let socket of this.sockets) {
+                socket.trigger = this.trigger.bind(this)
+                socket.triggerEvent = this.triggerEvent.bind(this)
+                socket.emit = this.emit.bind(this)
+            }
+
+        }
+
+        // Connect them all
+        return Promise.all(this.sockets.map(s => s.connect())).then(e => this)
+
+    }
+
+    /**
+     * This sends a message through the web socket
+     * @param {*} cmd
+     */
+    sendMessage (cmd) {
+        
+        // Send message to all sockets
+        for (let socket of this.sockets)
+            socket.sendMessage(cmd)
+
+    }
+
+    /**
+     * @public
+     * Forcefully closes the Web socket.
+     * Note: Socket will be set to null. Auto connect will be disabled.
+     */
+    close () {
+        
+        // Close all sockets
+        for (let socket of this.sockets) socket.close()
+        this.sockets = []
+        
+    }
+
+}

--- a/src/client/manager/WebSockets.js
+++ b/src/client/manager/WebSockets.js
@@ -12,10 +12,11 @@
 import EventEmitter from '../../internal/EventEmitter'
 
 export default class WebSockets extends EventEmitter {
-  constructor (store, client) {
+  constructor (store, client, address) {
     super()
     this.store = store
     this.client = client
+    this.address = address
 
     /** The WebSocket connection */
     this.socket = null
@@ -33,7 +34,7 @@ export default class WebSockets extends EventEmitter {
   }
 
   /**
-   * The connect function establishes a connection the Web socket.
+   * The connect function establishes a connection to the WebSocket.
    * @public
    * @return {Promise<WebSockets>}
    */
@@ -54,7 +55,7 @@ export default class WebSockets extends EventEmitter {
     }
 
     // Create the websocket
-    const url = `${this.store.wssocketAddress}/ws?app_id=${encodeURIComponent(this.store.appID)}&token=${encodeURIComponent(this.store.token)}`
+    const url = `${this.address}/ws?app_id=${encodeURIComponent(this.store.appID)}&token=${encodeURIComponent(this.store.token)}`
     this.socket = new WebSocket(url)
     this.socket.addEventListener('open', this.handleConnected.bind(this))
     this.socket.addEventListener('message', this.handleMessage.bind(this))


### PR DESCRIPTION
- Task: https://trello.com/c/j6gISi3i

This allows multiple web sockets to be used simultaneously, just specify an array for the `websocketAddress` config option instead of a string. (string is still supported though)